### PR TITLE
Updated docs for rpc example locally

### DIFF
--- a/trac-api/packages/javascript/README.md
+++ b/trac-api/packages/javascript/README.md
@@ -74,17 +74,112 @@ To use the API service interfaces, you will need to supply an rpcImpl function t
 example of how to do this for native gRPC calls is included in the documentation for protobuf.js: 
 [Using services in protobuf.js](https://www.npmjs.com/package/protobufjs#using-services).
 
-If you want to replace real network calls with a local implementation for testing, you can do that by providing an
+If you want to replace real network calls with a dummy local implementation for testing, you can do that by providing an
 alternate rpcImpl. Here is an example of how to do that.
+ 
+App.js:
 
-    class LocalServiceImpl {
+    import React from "react";
+    import {ExampleLogic} from "./apis/protobuf/exampleLogic";
     
-        constructor() {
-            // Set up whatever local data you are planning to use
-            this.localData = {};
+    // When called using null the search call will be a dummy with a spoofed response
+    const controllerRpc = new ExampleLogic(null)
+
+    function App() {
+    
+        const fakeSearchResults = controllerRpc.exampleSearch("ACME_CORP", {})
+    
+        return (
+    
+            <React.Fragment>
+                <div>
+                    Welcome to TRAC rpc calls in a React App using protobuf.js
+                </div>
+    
+                <div>
+                    {JSON.stringify(fakeSearchResults)}
+                </div>
+            </React.Fragment>
+        );
+    }
+    
+    export default App;
+
+exampleLogic.js
+
+    import {trac} from 'trac-js-api';
+    import {LocalServiceImpl} from "./localServiceImpl"
+
+    export class ExampleLogic {
+    
+        constructor(rpcImpl) {
+    
+            this.rpcImpl = rpcImpl
+    
+            if (rpcImpl !== null)
+                this.metaApi = new trac.api.TracMetadataApi(rpcImpl);
+    
+            else {
+                const localImpl = new LocalServiceImpl();
+                this.metaApi = new trac.api.TracMetadataApi(localImpl.createRpcImpl());
+            }
         }
     
-        // This method creates an rpcImpl that looks for available method implementations in the class
+        exampleSearch(tenant, search) {
+    
+            const searchRequest = {tenant: tenant, searchParams: search};
+    
+            const localImpl = new LocalServiceImpl();
+    
+            if (this.rpcImpl) {
+    
+                return this.metaApi.search(searchRequest)
+                    .then(response => {
+                        console.log(response)
+                    })  // handle response
+                    .catch(err => {
+                        console.log(err)
+                    });  // handle error
+    
+            } else {
+    
+                return localImpl.fakeSearch(searchRequest)
+    
+            }
+        }
+    }
+
+localServiceIpl.js
+
+    import {trac} from 'trac-js-api';
+
+    export class LocalServiceImpl {
+    
+        constructor() {
+    
+            // This needs to be a valid response, otherwise you get an empty
+            // object when creating the message
+            // TODO "FLOW" caused error see notes below
+            this.fakeResponseObject = {
+                searchResult: [{
+                    header: {
+                        "objectType": "FLOW",
+                        "objectId": "97f1a213-dc88-4cc8-9643-1e9f21018e27",
+                        "objectVersion": 1,
+                        "objectTimestamp": {
+                            "isoDatetime": "2021-03-24T15:50:09.766544Z"
+                        },
+                        "tagVersion": 1,
+                        "tagTimestamp": {
+                            "isoDatetime": "2021-03-24T15:50:09.766544Z"
+                        }
+                    },
+                    "attr": {}
+                }]
+            };
+        }
+    
+        // This method creates a real rpcImpl that looks for available method implementations in the class
         createRpcImpl() {
     
             const _self = this;
@@ -93,8 +188,7 @@ alternate rpcImpl. Here is an example of how to do that.
     
                 if (!method.name in _self || typeof _self[method.name] !== 'function') {
                     callback(new Error("Unknown API call " + method.name));
-                }
-                else {
+                } else {
     
                     try {
                         const response = _self[method.name](request);
@@ -108,46 +202,43 @@ alternate rpcImpl. Here is an example of how to do that.
         }
     
         // Now add whichever methods you need for testing as plain JS functions
-        search(searchProto) {
-
-            // Decode proto request
-            const searchRequest = trac.api.MetadataSearchRequest.decode(searchRequest);
-
-            const result = [...];  // Logic to build search results using this.localData
-            const searchResponse = {searchResult: result};
-
-            // Verification step (if required for dummy logic)
-            const err = trac.api.MetadataSearchResponse.verify(searchResponse);
-
-            if (err)
-                throw err;
-
-            // Encode proto result
-            return trac.api.MetadataSearchResponse.encode(searchResponse).finish();
-        }
+        fakeSearch(requestObject) {
     
-    }
-
-    class ExampleLogic {
-
-        constructor(rpcImpl) {
-
-            if (rpcImpl !== null)
-                this.metaApi = new trac.api.TracMetadataApi(rpcImpl);
-
-            else {
-                const localImpl = new LocalServiceImpl();
-                this.metaApi = new trac.api.TracMetadataApi(metaImpl.createRpcImpl());
-            }
-        }
-
-        exampleSearch() {
-
-            const search = {...};  // Create SearchParameters
-            const searchRequest = { tenant: tenant, searchParams: search});
-
-            this.metaApi.search(searchRequest)
-                .then(response => ...)  // handle response
-                .catch(err => ...);  // handle error
+            // Example of spoofing a response with a local variable rather than
+            // using a network call
+            const errRequest = trac.api.MetadataSearchRequest.verify(requestObject);
+    
+            if (errRequest)
+                throw errRequest;
+    
+            const requestMessage = trac.api.MetadataSearchRequest.create(requestObject)
+            console.log(`requestMessage = ${JSON.stringify(requestMessage)}`)
+    
+            const requestBuffer = trac.api.MetadataSearchRequest.encode(requestMessage).finish();
+            console.log(`requestBuffer = ${Array.prototype.toString.call(requestBuffer)}`)
+    
+            const requestDecode = trac.api.MetadataSearchRequest.decode(requestBuffer);
+            console.log(`requestDecode = ${JSON.stringify(requestDecode)}`)
+    
+            // Verification step can not be done on the JavaScript object because of the definition
+            // of objectType in the proto. When this is defined as enum it fails verification
+            // see https://github.com/protobufjs/protobuf.js/issues/1261
+            // The solution appears to not validate the object and use fromObject instead of encode.
+            // If you skip the verify check then use create then objectType returns OBJECT_TYPE_NOT_SET
+            // const errResponse = trac.api.MetadataSearchResponse.verify(this.fakeResponseObject);
+            //
+            // if (errResponse)
+            //     throw errResponse;
+    
+            const searchResponseMessage = trac.api.MetadataSearchResponse.fromObject(this.fakeResponseObject)
+            console.log(`searchResponseMessage = ${JSON.stringify(searchResponseMessage)}`)
+    
+            const searchResponseBuffer = trac.api.MetadataSearchResponse.encode(searchResponseMessage).finish()
+            console.log(`searchResponseBuffer = ${Array.prototype.toString.call(searchResponseBuffer)}`)
+    
+            const searchResponseDecoded = trac.api.MetadataSearchResponse.decode(searchResponseBuffer)
+            console.log(`searchResponseDecoded = ${JSON.stringify(searchResponseDecoded)}`)
+    
+            return searchResponseDecoded
         }
     }


### PR DESCRIPTION
This adds a real life example React App to the README.md that runs a valid dummy search using rpc. There are a few issues with this carried over from the previous version.