### PR TITLE
Fix Gradle function calling git version script

### DIFF
--- a/gradle/functions.gradle
+++ b/gradle/functions.gradle
@@ -15,14 +15,20 @@
  */
 
 
-static def getVersionFromGit() {
+def getVersionFromGit() {
 
     def osName = System.properties.getProperty('os.name').toLowerCase()
     def command = osName.contains("win")
         ? "powershell -ExecutionPolicy Bypass -File dev\\version.ps1"
         : "dev/version.sh"
 
-    def versionNumber = command.execute().text.strip()
+    def proc = command.execute([], rootDir)
+    def exitCode = proc.waitFor()
+
+    if (exitCode != 0)
+        throw new Exception("Get version command failed with error code ${exitCode}")
+
+    def versionNumber = proc.text.strip()
 
     println("TRAC Version: ${versionNumber}")
 


### PR DESCRIPTION
Problem manifests with macOS + IntelliJ IDEA 2021.1
Gradle not guaranteed to use rootDir for call to version script, so we set it explicitly