### PR TITLE
Feature/runtime exception hierarchy

### DIFF
--- a/trac-runtime/python/codegen/generator.py
+++ b/trac-runtime/python/codegen/generator.py
@@ -37,6 +37,16 @@ class LocationContext:
         return LocationContext(self.src_locations, self.src_loc_code, index, self.indent)
 
 
+class ECodeGeneration(RuntimeError):
+
+    """
+    An error occurred in the code generation process
+    (This is not part of the ETrac hierarchy as it is a build-time error)
+    """
+
+    pass
+
+
 class TracGenerator:
     
     _FieldType = pb_desc.FieldDescriptorProto.Type
@@ -381,10 +391,9 @@ class TracGenerator:
             return self.PROTO_TYPE_MAPPING[descriptor.type].__name__
 
         # Any unrecognised type is an error
-        raise RuntimeError(
+        raise ECodeGeneration(
             "Unknown type in protobuf field descriptor: field = {}, type code = {}"
-                .format(descriptor.name, descriptor.type))
-
+            .format(descriptor.name, descriptor.type))
 
     def generate_enum(self, ctx: LocationContext, descriptor: pb_desc.EnumDescriptorProto) -> str:
 
@@ -536,6 +545,8 @@ class TracGenerator:
             for field in message_descriptor.DESCRIPTOR.fields:
                 print(field.name)
 
-            raise RuntimeError("Field {} not found in type {}".format(field_name, message_descriptor.DESCRIPTOR.name))
+            raise ECodeGeneration(
+                "Field {} not found in type {}"
+                .format(field_name, message_descriptor.DESCRIPTOR.name))
 
         return field_descriptor.number

--- a/trac-runtime/python/src/trac/rt/exceptions.py
+++ b/trac-runtime/python/src/trac/rt/exceptions.py
@@ -148,6 +148,15 @@ class EModelRepo(ETrac):
     pass
 
 
+class EModelRepoConfig(EModelRepo):
+
+    """
+    Model repo referenced in metadata is either not supported or not configured
+    """
+
+    pass
+
+
 class EModelRepoCommunication(EModelRepo):
 
     """

--- a/trac-runtime/python/src/trac/rt/exceptions.py
+++ b/trac-runtime/python/src/trac/rt/exceptions.py
@@ -31,19 +31,61 @@ class EStartup(ETrac):
     pass
 
 
-class EBadConfig(ETrac):
+class EConfig(ETrac):
 
     """
     Indicates an error in a config file (either system or job config)
-
-    Includes errors for syntax, structure and config validation.
-    Doe not include errors loading the file, e.g. disk read failures or timeouts.
     """
 
     pass
 
 
-class EModelValidation(ETrac):
+class EConfigLoad(EConfig):
+
+    """
+    Config errors related to loading files and resources
+    Includes errors loading config from platform-specific backends using plugins (e.g. cloud key stores and buckets)
+    Does not include errors relating to the content of the configuration
+    """
+
+    pass
+
+
+class EConfigParse(EConfig):
+
+    """
+    Config errors relating to syntax, structure and config validation.
+    Does not include errors loading the file, e.g. disk read failures or timeouts.
+    """
+
+    pass
+
+
+class EValidation(ETrac):
+
+    """
+    Base class for validation errors.
+
+    Validation occurs on the inside of all platform interfaces,
+    including the runtime API for models, the web API and the CLI and platform/jpb config interfaces
+    """
+
+    pass
+
+
+class EJobValidation(EValidation):
+
+    """
+    A job submitted to the engine has failed validation
+
+    This could be because the job config is invalid or does not align with the platform config
+    It could also happen if the job references resources that are superseded or expunged
+    """
+
+    pass
+
+
+class EModelValidation(EValidation):
 
     """
     Validation failure when a model is imported or loaded
@@ -55,7 +97,7 @@ class EModelValidation(ETrac):
     pass
 
 
-class ERuntimeValidation(ETrac):
+class ERuntimeValidation(EValidation):
 
     """
     Validation failure when a model calls into the TRAC API using the methods in TracContext
@@ -64,7 +106,7 @@ class ERuntimeValidation(ETrac):
     pass
 
 
-class EDataValidation(ETrac):
+class EDataValidation(EValidation):
 
     """
     Validation failure when a model output is checked for conformance to its data schema

--- a/trac-runtime/python/src/trac/rt/exceptions.py
+++ b/trac-runtime/python/src/trac/rt/exceptions.py
@@ -188,17 +188,37 @@ class EModelRepoRequest(EModelRepo):
     pass
 
 
+class ETracInternal(ETrac):
+
+    """
+    An internal error has occurred in the TRAC runtime engine (this is a bug)
+
+    This error indicates a problem with the runtime engine or with one of its subsystems or plugins.
+    It should be used to guard against error conditions between different modules or sub-systems in the engine.
+    In most cases an internal error will cause the platform to shut down, however there may be cases in some
+    modules where these errors can be handled (e.g. by discarding a failing plugin).
+
+    This error can be raised e.g. by an internal component that receives an invalid request from client code
+    in another part of the engine. For error conditions that are wholly under the control o a single module
+    or sub-system, use EUnexpected instead.
+    """
+
+    pass
+
+
 class EUnexpected(ETrac):
 
     """
     An unexpected error has occurred in the TRAC runtime engine (this is a bug)
 
     This error always indicates a bug, it signals that the engine is in an inconsistent state.
-    It should never be raised for errors that might legitimately occur during normal operation.
+    It should be used only for errors that can never happen, within the scope of a module or sub-system
+    when that module is accessed via its public API. Never use EUnexpected for expected errors!
     The runtime will be shut down with a failed exit code, any running or pending jobs will also be failed.
 
-    This error can be raised for failed sanity checks, where the engine should guarantee some condition
-    and that condition has not been met.
+    This error can be raised e.g. for failed sanity checks, where the engine should guarantee some condition
+    and that condition has not been met. For error conditions that might occur as a result of problems in
+    other parts of the engine (but not relating to external systems), use ETracInternal instead.
     """
 
     pass

--- a/trac-runtime/python/src/trac/rt/exceptions.py
+++ b/trac-runtime/python/src/trac/rt/exceptions.py
@@ -272,5 +272,4 @@ class EUnexpected(ETrac):
     If this condition is not met, use ETracInternal instead.
     """
 
-    def __init__(self):
-        super(EUnexpected, self).__init__("Unexpected internal error (this is a bug)")
+    pass

--- a/trac-runtime/python/src/trac/rt/exceptions.py
+++ b/trac-runtime/python/src/trac/rt/exceptions.py
@@ -168,3 +168,19 @@ class EModelRepoRequest(EModelRepo):
     """
 
     pass
+
+
+class EUnexpected(ETrac):
+
+    """
+    An unexpected error has occurred in the TRAC runtime engine (this is a bug)
+
+    This error always indicates a bug, it signals that the engine is in an inconsistent state.
+    It should never be raised for errors that might legitimately occur during normal operation.
+    The runtime will be shut down with a failed exit code, any running or pending jobs will also be failed.
+
+    This error can be raised for failed sanity checks, where the engine should guarantee some condition
+    and that condition has not been met.
+    """
+
+    pass

--- a/trac-runtime/python/src/trac/rt/exceptions.py
+++ b/trac-runtime/python/src/trac/rt/exceptions.py
@@ -99,6 +99,15 @@ class EStorage(ETrac):
     pass
 
 
+class EStorageConfig(EStorage):
+
+    """
+    Storage referenced in metadata is either not supported or not configured
+    """
+
+    pass
+
+
 class EStorageCommunication(EStorage):
 
     """

--- a/trac-runtime/python/src/trac/rt/exceptions.py
+++ b/trac-runtime/python/src/trac/rt/exceptions.py
@@ -236,13 +236,21 @@ class ETracInternal(ETrac):
     An internal error has occurred in the TRAC runtime engine (this is a bug)
 
     This error indicates a problem with the runtime engine or with one of its subsystems or plugins.
-    It should be used to guard against error conditions between different modules or sub-systems in the engine.
-    In most cases an internal error will cause the platform to shut down, however there may be cases in some
-    modules where these errors can be handled (e.g. by discarding a failing plugin).
+    It always represents a bug (although sometimes there may be a genuine error as well that has not been
+    properly handled). Internal errors are normally fatal because the engine has gone into an inconsistent state.
+    A few special cases may be recoverable (e.g. discarding a failing plugin on load).
+    """
 
-    This error can be raised e.g. by an internal component that receives an invalid request from client code
-    in another part of the engine. For error conditions that are wholly under the control o a single module
-    or sub-system, use EUnexpected instead.
+    pass
+
+
+class EValidationGap(ETracInternal):
+
+    """
+    A validation error has occurred in the TRAC runtime engine (this is a bug)
+
+    A validation gap is a type of internal error, it indicates a condition inside
+    TRAC that should have been caught higher up the stack in a validation layer.
     """
 
     pass
@@ -253,14 +261,16 @@ class EUnexpected(ETrac):
     """
     An unexpected error has occurred in the TRAC runtime engine (this is a bug)
 
-    This error always indicates a bug, it signals that the engine is in an inconsistent state.
-    It should be used only for errors that can never happen, within the scope of a module or sub-system
-    when that module is accessed via its public API. Never use EUnexpected for expected errors!
-    The runtime will be shut down with a failed exit code, any running or pending jobs will also be failed.
+    An unexpected error is an internal error that should never happen, it represents a logical
+    inconsistency within a single component or subsystem. For example, a failed sanity
+    check or a case where a condition that should be guaranteed is not met. Unexpected errors
+    are always fatal.
 
-    This error can be raised e.g. for failed sanity checks, where the engine should guarantee some condition
-    and that condition has not been met. For error conditions that might occur as a result of problems in
-    other parts of the engine (but not relating to external systems), use ETracInternal instead.
+    The conditions for EUnexpected should be wholly expressed by a single component or subsystem.
+    If a component exposes an interface to other components of the engine, and requests via that interface
+    are invalid or can put the component into an illegal state, that does not count as unexpected.
+    If this condition is not met, use ETracInternal instead.
     """
 
-    pass
+    def __init__(self):
+        super(EUnexpected, self).__init__("Unexpected internal error (this is a bug)")

--- a/trac-runtime/python/src/trac/rt/exec/dev_mode.py
+++ b/trac-runtime/python/src/trac/rt/exec/dev_mode.py
@@ -22,6 +22,7 @@ import uuid
 import trac.rt.api as api
 import trac.rt.metadata as meta
 import trac.rt.config as cfg
+import trac.rt.exceptions as _ex
 import trac.rt.impl.repositories as _repos
 import trac.rt.impl.storage as _storage
 import trac.rt.impl.util as util
@@ -110,14 +111,14 @@ class DevModeTranslator:
             storage_path = data_value.get("path")
 
             if not storage_path:
-                raise RuntimeError(f"Invalid configuration for input '{data_key}' (missing required value 'path'")
+                raise _ex.EConfigParse(f"Invalid configuration for input '{data_key}' (missing required value 'path'")
 
             storage_key = data_value.get("storageKey") or sys_config.storageSettings.defaultStorage
             storage_format = data_value.get("format") or sys_config.storageSettings.defaultFormat
             snap = 1
 
         else:
-            raise RuntimeError(f"Invalid configuration for input '{data_key}'")
+            raise _ex.EConfigParse(f"Invalid configuration for input '{data_key}'")
 
         cls._log.info(f"Generating data definition for '{data_key}' (assigned ID {data_id})")
 

--- a/trac-runtime/python/src/trac/rt/exec/functions.py
+++ b/trac-runtime/python/src/trac/rt/exec/functions.py
@@ -149,7 +149,7 @@ class DataItemFunc(NodeFunction):
         return delta
 
 
-class DataIoFunc(NodeFunction, abc.ABC):
+class _LoadSaveDataFunc(NodeFunction, abc.ABC):
 
     def __init__(self, storage: _storage.StorageManager):
         self.storage = storage
@@ -179,7 +179,7 @@ class DataIoFunc(NodeFunction, abc.ABC):
         return copy
 
 
-class LoadDataFunc(DataIoFunc):
+class LoadDataFunc(_LoadSaveDataFunc):
 
     def __init__(self, node: LoadDataNode, storage: _storage.StorageManager):
         super().__init__(storage)
@@ -209,7 +209,7 @@ class LoadDataFunc(DataIoFunc):
             raise NotImplementedError("Directory storage format not available yet")
 
 
-class SaveDataFunc(DataIoFunc):
+class SaveDataFunc(_LoadSaveDataFunc):
 
     def __init__(self, node: SaveDataNode, storage: _storage.StorageManager):
         super().__init__(storage)
@@ -298,7 +298,7 @@ class FunctionResolver:
         resolve_func = self.__node_mapping[node.__class__]
 
         if resolve_func is None:
-            raise RuntimeError()  # TODO: Error
+            raise _ex.EUnexpected()
 
         return resolve_func(self, job_config, node)
 

--- a/trac-runtime/python/src/trac/rt/exec/functions.py
+++ b/trac-runtime/python/src/trac/rt/exec/functions.py
@@ -156,17 +156,20 @@ class _LoadSaveDataFunc(NodeFunction, abc.ABC):
 
     def _choose_copy(self, data_item: str, storage_def: meta.StorageDefinition) -> meta.StorageCopy:
 
+        # Metadata should be checked for consistency before a job is accepted
+        # An error here indicates a validation gap
+
         storage_info = storage_def.dataItems.get(data_item)
 
         if storage_info is None:
-            raise RuntimeError("Invalid metadata")  # TODO: Error
+            raise _ex.EValidationGap()
 
         incarnation = next(filter(
             lambda i: i.incarnationStatus == meta.IncarnationStatus.INCARNATION_AVAILABLE,
             reversed(storage_info.incarnations)), None)
 
         if incarnation is None:
-            raise RuntimeError("Data item not available (it has been expunged)")  # TODO: Error
+            raise _ex.EValidationGap()
 
         copy = next(filter(
             lambda c: c.copyStatus == meta.CopyStatus.COPY_AVAILABLE
@@ -174,7 +177,7 @@ class _LoadSaveDataFunc(NodeFunction, abc.ABC):
             incarnation.copies), None)
 
         if copy is None:
-            raise RuntimeError("No copy of the data is available in a connected storage location")  # TODO: Error
+            raise _ex.EValidationGap()
 
         return copy
 

--- a/trac-runtime/python/src/trac/rt/exec/graph_builder.py
+++ b/trac-runtime/python/src/trac/rt/exec/graph_builder.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 
 import trac.rt.config.config as config
+import trac.rt.exceptions as _ex
 
 from .graph import *
 
@@ -25,7 +26,7 @@ class GraphBuilder:
         target_def = job_config.objects.get(job_config.target)
 
         if target_def is None:
-            raise RuntimeError(f"No definition available for job target '{job_config.target}'")  # TODO: Error
+            raise _ex.EConfigParse(f"No definition available for job target '{job_config.target}'")
 
         # Only calculation jobs are supported at present
         return GraphBuilder.build_calculation_job(job_config)
@@ -197,7 +198,7 @@ class GraphBuilder:
             return GraphBuilder.build_flow(job_config, namespace, graph, model_or_flow.flow)
 
         else:
-            raise RuntimeError("Invalid job config given to the execution engine")  # TODO: Error
+            raise _ex.EConfigParse("Invalid job config given to the execution engine")
 
     @staticmethod
     def build_model(

--- a/trac-runtime/python/src/trac/rt/exec/runtime.py
+++ b/trac-runtime/python/src/trac/rt/exec/runtime.py
@@ -196,12 +196,6 @@ class TracRuntime:
             self._log.error(f"TRAC runtime failed to start due to an internal error (this is a bug)")
             raise
 
-        # Unexpected error - something has gone very wrong, unexpected errors mean a basic sanity check has failed
-        # Propagate original exception, this is not a startup error
-        except _ex.EUnexpected:
-            self._log.error(f"TRAC runtime failed to start due to an unexpected error (this is a bug)")
-            raise
-
         # An expected startup error - e.g. missing or bad config, properly handled in the startup code
         # Propagate as EStartup
         except _ex.EStartup as e:

--- a/trac-runtime/python/src/trac/rt/exec/runtime.py
+++ b/trac-runtime/python/src/trac/rt/exec/runtime.py
@@ -21,6 +21,7 @@ import typing as tp
 
 import trac.rt.api as api
 import trac.rt.config.config as config
+import trac.rt.exceptions as _ex
 import trac.rt.impl.config_parser as cfg
 import trac.rt.impl.util as util
 import trac.rt.impl.repositories as repos
@@ -37,10 +38,11 @@ class TracRuntime:
             self, sys_config_path: str, job_config_path: tp.Optional[str] = None,
             dev_mode: bool = False, model_class: tp.Optional[api.TracModel.__class__] = None):
 
+        trac_version = 'DEVELOPMENT VERSION'  # TODO: Bring in version from the version script
         python_version = sys.version.replace("\n", "")
         mode = "batch" if job_config_path else "service"
 
-        print(f">>> TRAC Python Runtime {'DEVELOPMENT VERSION'} starting {mode} at {dt.datetime.now()}")
+        print(f">>> TRAC Python Runtime {trac_version} starting in {mode} mode at {dt.datetime.now()}")
         print(f">>> Python installation: {python_version} ({sys.exec_prefix})")
         print(f">>> Working directory: {pathlib.Path.cwd()}")
         print(f">>> System config: {sys_config_path}")
@@ -51,8 +53,9 @@ class TracRuntime:
         if dev_mode:
             print(f">>> Development mode enabled (DO NOT USE THIS IN PRODUCTION)")
 
-        util.configure_logging(self.__class__)
+        util.configure_logging()
         self._log = util.logger_for_object(self)
+        self._log.info(f"TRAC Python Runtime {trac_version}")
 
         self._sys_config_path = sys_config_path
         self._sys_config: tp.Optional[config.SystemConfig] = None
@@ -93,36 +96,50 @@ class TracRuntime:
 
     def pre_start(self):
 
-        # Plugins will be loaded here, before config
+        try:
 
-        self._log.info("Loading system config...")
-        raw_sys_config = cfg.ConfigParser.load_raw_config(self._sys_config_path)
-        self._sys_config = cfg.ConfigParser(config.SystemConfig).parse(raw_sys_config, self._sys_config_path)
+            self._log.info(f"Beginning pre-start sequence...")
 
-        if self._batch_mode:
-            self._log.info("Loading job config...")
-            raw_job_config = cfg.ConfigParser.load_raw_config(self._job_config_path)
-            self._job_config = cfg.ConfigParser(config.JobConfig).parse(raw_job_config, self._job_config_path)
+            # Plugins will be loaded here, before config
 
-        if self._dev_mode:
+            # self._log.info("Loading system config...")
+            sys_config_parser = cfg.ConfigParser(config.SystemConfig)
+            sys_config_raw = sys_config_parser.load_raw_config(self._sys_config_path, config_file_name="system")
+            self._sys_config = sys_config_parser.parse(sys_config_raw, self._sys_config_path)
 
-            job_config, sys_config = _dev_mode.DevModeTranslator.translate_dev_mode_config(
-                self._job_config, self._sys_config, self._model_class)
+            if self._batch_mode:
+                # self._log.info("Loading job config...")
+                job_config_parser = cfg.ConfigParser(config.JobConfig)
+                job_config_raw = job_config_parser.load_raw_config(self._job_config_path, config_file_name="job")
+                self._job_config = job_config_parser.parse(job_config_raw, self._job_config_path)
 
-            self._job_config = job_config
-            self._sys_config = sys_config
+            if self._dev_mode:
+
+                job_config, sys_config = _dev_mode.DevModeTranslator.translate_dev_mode_config(
+                    self._job_config, self._sys_config, self._model_class)
+
+                self._job_config = job_config
+                self._sys_config = sys_config
+
+        except Exception as e:
+            self._handle_startup_error(e)
 
     def start(self, wait: bool = False):
 
-        self._log.info("Starting the engine")
+        try:
 
-        self._repos = repos.Repositories(self._sys_config)
-        self._storage = storage.StorageManager(self._sys_config)
+            self._log.info("Starting the engine...")
 
-        self._engine = engine.TracEngine(self._sys_config, self._repos, self._storage, batch_mode=self._batch_mode)
-        self._system = actors.ActorSystem(self._engine, system_thread="engine")
+            self._repos = repos.Repositories(self._sys_config)
+            self._storage = storage.StorageManager(self._sys_config)
 
-        self._system.start(wait=wait)
+            self._engine = engine.TracEngine(self._sys_config, self._repos, self._storage, batch_mode=self._batch_mode)
+            self._system = actors.ActorSystem(self._engine, system_thread="engine")
+
+            self._system.start(wait=wait)
+
+        except Exception as e:
+            self._handle_startup_error(e)
 
     def stop(self):
 
@@ -137,7 +154,10 @@ class TracRuntime:
             self._log.info("TRAC runtime has gone down cleanly")
         else:
             self._log.error("TRAC runtime has gone down with errors")
-            raise RuntimeError("TRAC runtime has gone down with errors") from self._system.shutdown_error()
+
+            # For now, use the final error that propagated in the engine as the shutdown error
+            # A more sophisticated approach would handle job-related errors by writing job output metadata
+            raise self._system.shutdown_error()
 
     # ------------------------------------------------------------------------------------------------------------------
     # Job submission
@@ -146,13 +166,56 @@ class TracRuntime:
     def submit_job(self, job_config_path: str):
 
         if self._batch_mode:
-            raise RuntimeError()  # TODO: Error
+            msg = "Additional jobs cannot be submitted in batch mode"
+            self._log.error(msg)
+            raise _ex.EJobValidation(msg)
 
         self._system.send("submit_job", job_config_path)
 
     def submit_batch(self):
 
         if not self._batch_mode:
-            raise RuntimeError()  # TODO Error
+            msg = "Batch jobs cannot be triggered in service mode"
+            self._log.error(msg)
+            raise _ex.EJobValidation(msg)
 
         self._system.send("submit_job", self._job_config)
+
+    # ------------------------------------------------------------------------------------------------------------------
+    # Error handling
+    # ------------------------------------------------------------------------------------------------------------------
+
+    def _handle_startup_error(self, error: Exception):
+
+        try:
+            raise error
+
+        # Internal error - something has gone wrong with the engine
+        # Propagate original exception, this is not a startup error
+        except _ex.ETracInternal:
+            self._log.error(f"TRAC runtime failed to start due to an internal error (this is a bug)")
+            raise
+
+        # Unexpected error - something has gone very wrong, unexpected errors mean a basic sanity check has failed
+        # Propagate original exception, this is not a startup error
+        except _ex.EUnexpected:
+            self._log.error(f"TRAC runtime failed to start due to an unexpected error (this is a bug)")
+            raise
+
+        # An expected startup error - e.g. missing or bad config, properly handled in the startup code
+        # Propagate as EStartup
+        except _ex.EStartup as e:
+            self._log.error(f"TRAC runtime failed to start: {e}")
+            raise
+
+        # An expected error, but without explict handling in te startup code
+        # Wrap expected errors during the startup sequence in EStartup
+        except _ex.ETrac as e:
+            self._log.error(f"TRAC runtime failed to start: {e}")
+            raise _ex.EStartup("TRAC runtime failed to start") from e
+
+        # The worst case, an error that was never handled at all, e.g. an unexpected null reference
+        # Wrap with EUnexpected so at least we don't exit with a raw exception from somewhere deep in the stack!
+        except Exception as e:
+            self._log.error(f"TRAC runtime failed to start due to an unhandled error (this is a bug)")
+            raise _ex.EUnexpected("An unhandled error propagated to the top level error handler (this is a bug)") from e

--- a/trac-runtime/python/src/trac/rt/impl/util.py
+++ b/trac-runtime/python/src/trac/rt/impl/util.py
@@ -87,7 +87,7 @@ class ColorFormatter(logging.Formatter):
         return f"\033[{1 if is_bold else 0};{base_code + color_offset}m"
 
 
-def configure_logging(clazz: type = None):
+def configure_logging():
 
     root_logger = logging.getLogger()
 
@@ -110,13 +110,6 @@ def configure_logging(clazz: type = None):
         console_handler.setLevel(logging.INFO)
         trac_logger.addHandler(console_handler)
         trac_logger.propagate = False
-
-    if clazz is None:
-        startup_logger = logger_for_namespace("trac.rt")
-    else:
-        startup_logger = logger_for_class(clazz)
-
-    startup_logger.info("Logging enabled")
 
 
 def logger_for_object(obj: object) -> logging.Logger:


### PR DESCRIPTION
Use a structured exception hierarchy for all errors raised in the python runtime.

Many of the runtime exception classes are the same as those defined in the Java platform components, i.e. they have the same name and mean the same thing. Using the same hierarchy everywhere adds clarity and may eventually make it possible to pass full error info between components.