### PR TITLE
Feature / Basic config validation

### DIFF
--- a/trac-runtime/python/src/trac/rt/impl/config_parser.py
+++ b/trac-runtime/python/src/trac/rt/impl/config_parser.py
@@ -243,7 +243,7 @@ class ConfigParser(tp.Generic[_T]):
                 self._error(location, message)
                 init_values.append(None)
 
-            elif param_name in raw_dict:
+            elif param_name in raw_dict and raw_dict[param_name] is not None:
                 param_value = self._parse_value(param_location, raw_dict[param_name], param_type)
                 init_values.append(param_value)
 

--- a/trac-runtime/python/src/trac/rt/impl/storage.py
+++ b/trac-runtime/python/src/trac/rt/impl/storage.py
@@ -24,6 +24,7 @@ import pandas as pd
 import trac.rt.metadata as _meta
 import trac.rt.config as _cfg
 import trac.rt.exceptions as _ex
+import trac.rt.impl.util as _util
 
 
 class FileType(enum.Enum):
@@ -151,6 +152,7 @@ class StorageManager:
 
     def __init__(self, sys_config: _cfg.SystemConfig):
 
+        self.__log = _util.logger_for_object(self)
         self.__file_storage: tp.Dict[str, IFileStorage] = dict()
         self.__data_storage: tp.Dict[str, IDataStorage] = dict()
 
@@ -176,6 +178,11 @@ class StorageManager:
 
     def get_file_storage(self, storage_key: str) -> IFileStorage:
 
+        if not self.has_file_storage(storage_key):
+            err = f"File storage is not configured for storage key [{storage_key}]"
+            self.__log.error(err)
+            raise _ex.EStorageConfig(err)
+
         return self.__file_storage[storage_key]
 
     def has_data_storage(self, storage_key: str) -> bool:
@@ -183,6 +190,11 @@ class StorageManager:
         return storage_key in self.__data_storage
 
     def get_data_storage(self, storage_key: str) -> IDataStorage:
+
+        if not self.has_data_storage(storage_key):
+            err = f"Data storage is not configured for storage key [{storage_key}]"
+            self.__log.error(err)
+            raise _ex.EStorageConfig(err)
 
         return self.__data_storage[storage_key]
 

--- a/trac-runtime/python/src/trac/rt/impl/storage.py
+++ b/trac-runtime/python/src/trac/rt/impl/storage.py
@@ -161,10 +161,20 @@ class StorageManager:
 
     def create_storage(self, storage_key: str, storage_config: _cfg.StorageConfig):
 
+        if storage_config is None:
+            err = f"Missing config for storage key [{storage_key}]"
+            self.__log.error(err)
+            raise _ex.EStorageConfig(err)
+
         storage_type = storage_config.storageType
 
         file_impl = self.__file_impls.get(storage_type)
         data_impl = self.__data_impls.get(storage_type)
+
+        if file_impl is None or data_impl is None:
+            err = f"Storage type [{storage_type}] is not available"
+            self.__log.error(err)
+            raise _ex.EStorageConfig(err)
 
         file_storage = file_impl(storage_config)
         data_storage = data_impl(storage_config, file_storage)

--- a/trac-runtime/python/test/trac_test/rt/impl/__init__.py
+++ b/trac-runtime/python/test/trac_test/rt/impl/__init__.py
@@ -1,0 +1,13 @@
+#  Copyright 2021 Accenture Global Solutions Limited
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.

--- a/trac-runtime/python/test/trac_test/rt/impl/test_config_parser.py
+++ b/trac-runtime/python/test/trac_test/rt/impl/test_config_parser.py
@@ -1,0 +1,78 @@
+#  Copyright 2021 Accenture Global Solutions Limited
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import unittest
+import pathlib
+
+import trac.rt.config as cfg
+import trac.rt.impl.config_parser as cfg_p
+import trac.rt.impl.util as util
+import trac.rt.exceptions as ex
+
+
+ROOT_DIR = pathlib.Path(__file__).parent \
+    .joinpath("../../../../../..") \
+    .resolve()
+
+PYTHON_EXAMPLES_DIR = ROOT_DIR \
+    .joinpath("examples/models/python")
+
+
+class ConfigParserTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        util.configure_logging()
+
+    def test_example_sys_config_ok(self):
+
+        parser = cfg_p.ConfigParser(cfg.SystemConfig)
+
+        raw_config_path = PYTHON_EXAMPLES_DIR.joinpath("sys_config.yaml")
+        raw_config = parser.load_raw_config(raw_config_path, "system")
+        sys_config = parser.parse(raw_config, raw_config_path.name)
+
+        self.assertIsInstance(sys_config, cfg.SystemConfig)
+
+    def test_example_job_config_ok(self):
+
+        parser = cfg_p.ConfigParser(cfg.JobConfig)
+
+        raw_config_path = PYTHON_EXAMPLES_DIR.joinpath("hello_pandas/hello_pandas.yaml")
+        raw_config = parser.load_raw_config(raw_config_path, "job")
+        job_config = parser.parse(raw_config, raw_config_path.name)
+
+        self.assertIsInstance(job_config, cfg.JobConfig)
+
+    def test_invalid_path(self):
+
+        parser = cfg_p.ConfigParser(cfg.SystemConfig)
+
+        self.assertRaises(ex.EConfigLoad, lambda: parser.load_raw_config(None))      # noqa
+        self.assertRaises(ex.EConfigLoad, lambda: parser.load_raw_config(object()))  # noqa
+        self.assertRaises(ex.EConfigLoad, lambda: parser.load_raw_config(""))
+        self.assertRaises(ex.EConfigLoad, lambda: parser.load_raw_config("$%^&*--`!"))
+        self.assertRaises(ex.EConfigLoad, lambda: parser.load_raw_config("pigeon://pigeon-svr/lovely-pigeon.pg"))
+
+    def test_config_file_not_found(self):
+
+        nonexistent_path = PYTHON_EXAMPLES_DIR.joinpath("nonexistent.yaml")
+
+        parser = cfg_p.ConfigParser(cfg.SystemConfig)
+        self.assertRaises(ex.EConfigLoad, lambda: parser.load_raw_config(nonexistent_path))
+
+    def test_config_file_is_a_folder(self):
+
+        parser = cfg_p.ConfigParser(cfg.SystemConfig)
+        self.assertRaises(ex.EConfigLoad, lambda: parser.load_raw_config(PYTHON_EXAMPLES_DIR))


### PR DESCRIPTION
Add some basic checks around loading and applying runtime config, to catch common errors.

This is not an exhaustive validation, which is needed to close config validation gaps. However it should help provide useful messages in some off the most common error cases.