### PR TITLE
Prepare 0.3 release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,9 +74,9 @@ jobs:
       matrix:
         enviroment:
 
-          - { ENV_NAME: "Latest: Python 3.9, PySpark 3.1.x, Pandas >= 1.3",
+          - { ENV_NAME: "Latest: Python 3.9, PySpark 3.2.x, Pandas >= 1.3",
               PYTHON_VERSION: "3.9",
-              PYSPARK_VERSION: ">= 3.1.0, < 3.2.0",
+              PYSPARK_VERSION: ">= 3.2.0, < 3.3.0",
               PANDAS_VERSION: ">= 1.3.0, < 2.0.0",
               PYPANDOC: false }
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,8 +74,8 @@ jobs:
       matrix:
         enviroment:
 
-          - { ENV_NAME: "Latest: Python 3.9, PySpark 3.2.x, Pandas >= 1.3",
-              PYTHON_VERSION: "3.9",
+          - { ENV_NAME: "Latest: Python 3.10, PySpark 3.2.x, Pandas >= 1.3",
+              PYTHON_VERSION: "3.10",
               PYSPARK_VERSION: ">= 3.2.0, < 3.3.0",
               PANDAS_VERSION: ">= 1.3.0, < 2.0.0",
               PYPANDOC: false }

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -8,7 +8,7 @@ on:
   # Re-run compliance jobs in main, to make sure there are no issues from the merge
   push:
     branches:
-      - '**'
+      - main
 
   # Use the release:publish event to generate compliance reports for releases
   # This lines up with the packaging workflow, so reports will be published when packages are published

--- a/README.md
+++ b/README.md
@@ -39,10 +39,11 @@ https://github.com/Accenture/trac/actions/workflows/integration.yml)
 [![Packaging](https://github.com/Accenture/trac/actions/workflows/packaging.yml/badge.svg)](
 https://github.com/Accenture/trac/actions/workflows/packaging.yml)
 
-The current release series (0.2.x) is intended for reference and experimentation.
-It includes the metadata service, runtime engine for Python and a partial implementation
-of the platform Gateway. This release can be used to prototype client applications (e.g.
-web UIs) and to build and run models in a development sandbox.
+The current release series (0.3.x) is intended for reference and experimentation.
+It includes the metadata service, data service and core data engine, runtime engine
+for Python and a partial implementation of the platform Gateway. This release can
+be used to prototype client applications (e.g. web UIs) and to build and run models
+in a development sandbox.
 
 At the moment TRAC's API calls and metadata structures are subject to change between 
 versions, including between point versions. As the platform evolves these APIs will

--- a/trac-runtime/python/README.md
+++ b/trac-runtime/python/README.md
@@ -18,7 +18,7 @@ The TRAC runtime for Python has these requirements:
 
 * Python: 3.7 or later
 * Pandas: 1.0 or later
-* PySpark 2.4.x, 3.0.x or 3.1.x
+* PySpark 2.4.x, 3.0.x, 3.1.x or 3.2.x
 
 Not every combination of versions will work, e.g. PySpark 3 requires Python 3.8.
 

--- a/trac-runtime/python/README.md
+++ b/trac-runtime/python/README.md
@@ -18,7 +18,7 @@ The TRAC runtime for Python has these requirements:
 
 * Python: 3.7 or later
 * Pandas: 1.0 or later
-* PySpark 2.4.x, 3.0.x, 3.1.x or 3.2.x
+* PySpark 2.4.x or 3.x
 
 Not every combination of versions will work, e.g. PySpark 3 requires Python 3.8.
 

--- a/trac-runtime/python/setup.cfg
+++ b/trac-runtime/python/setup.cfg
@@ -53,5 +53,5 @@ python_requires = >=3.7
 
 install_requires =
     pandas >= 1.0.0, < 2.0.0
-    pyspark >= 2.4.0, < 3.2.0
+    pyspark >= 2.4.0, < 3.3.0
     pyyaml >= 5.3.0, < 6.0.0


### PR DESCRIPTION
Update supported versions of Python and PySpark (test against Python 3.10 / PySpark 3.2)
Update READMEs for 0.3 release