### PR TITLE
Set Java compatibility level at Java 11

### DIFF
--- a/gradle/base-java.gradle
+++ b/gradle/base-java.gradle
@@ -31,6 +31,16 @@ dependencies {
     testImplementation group: 'org.mockito', name: 'mockito-core', version: "$mockito_version"
 }
 
+java {
+
+    // We want to allow compiling with higher versions of Java as well
+    // Setting toolchain.languageVersion does not make it easy to do this
+    // So, stick to the old source/target compatibility settings for now
+
+    sourceCompatibility = "$java_min_version"
+    targetCompatibility = "$java_min_version"
+}
+
 compileJava {
     options.compilerArgs << '-parameters'
 }

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -16,6 +16,8 @@
 
 ext {
 
+    java_min_version = JavaVersion.VERSION_11
+
     guava_version = '31.0.1-jre'
 
     netty_version = '4.1.72.Final'


### PR DESCRIPTION
Stops the IDE from suggesting Java 17 language features!