### PR TITLE
Fix / Simplify naming of flow edges

### DIFF
--- a/examples/rest_calls/create_flow.json
+++ b/examples/rest_calls/create_flow.json
@@ -65,23 +65,23 @@
         "edges": [
 
             {
-                "head": { "node": "simulate_customer_transactions", "socket": "initial_accounts" },
-                "tail": { "node": "customer_accounts" }
+                "to": { "node": "simulate_customer_transactions", "socket": "initial_accounts" },
+                "from": { "node": "customer_accounts" }
             },
 
             {
-                "head": { "node": "simulate_customer_transactions", "socket": "economic_scenario" },
-                "tail": { "node": "economic_scenario" }
+                "to": { "node": "simulate_customer_transactions", "socket": "economic_scenario" },
+                "from": { "node": "economic_scenario" }
             },
 
             {
-                "head": { "node": "simulate_joiners_and_leavers", "socket": "initial_accounts" },
-                "tail": { "node": "simulate_customer_transactions", "socket": "simulated_accounts" }
+                "to": { "node": "simulate_joiners_and_leavers", "socket": "initial_accounts" },
+                "from": { "node": "simulate_customer_transactions", "socket": "simulated_accounts" }
             },
 
              {
-                 "head": { "node": "simulated_accounts" },
-                 "tail": { "node": "simulate_joiners_and_leavers", "socket": "simulated_accounts" }
+                 "to": { "node": "simulated_accounts" },
+                 "from": { "node": "simulate_joiners_and_leavers", "socket": "simulated_accounts" }
              }
         ]
 

--- a/examples/rest_calls/create_flow.json
+++ b/examples/rest_calls/create_flow.json
@@ -65,23 +65,23 @@
         "edges": [
 
             {
-                "to": { "node": "simulate_customer_transactions", "socket": "initial_accounts" },
-                "from": { "node": "customer_accounts" }
+                "target": { "node": "simulate_customer_transactions", "socket": "initial_accounts" },
+                "source": { "node": "customer_accounts" }
             },
 
             {
-                "to": { "node": "simulate_customer_transactions", "socket": "economic_scenario" },
-                "from": { "node": "economic_scenario" }
+                "target": { "node": "simulate_customer_transactions", "socket": "economic_scenario" },
+                "source": { "node": "economic_scenario" }
             },
 
             {
-                "to": { "node": "simulate_joiners_and_leavers", "socket": "initial_accounts" },
-                "from": { "node": "simulate_customer_transactions", "socket": "simulated_accounts" }
+                "target": { "node": "simulate_joiners_and_leavers", "socket": "initial_accounts" },
+                "source": { "node": "simulate_customer_transactions", "socket": "simulated_accounts" }
             },
 
              {
-                 "to": { "node": "simulated_accounts" },
-                 "from": { "node": "simulate_joiners_and_leavers", "socket": "simulated_accounts" }
+                 "target": { "node": "simulated_accounts" },
+                 "source": { "node": "simulate_joiners_and_leavers", "socket": "simulated_accounts" }
              }
         ]
 

--- a/trac-api/trac-metadata/src/main/proto/trac/metadata/flow.proto
+++ b/trac-api/trac-metadata/src/main/proto/trac/metadata/flow.proto
@@ -53,8 +53,8 @@ message FlowSocket {
 
 message FlowEdge {
 
-  FlowSocket from = 1;
-  FlowSocket to = 2;
+  FlowSocket source = 1;
+  FlowSocket target = 2;
 }
 
 

--- a/trac-api/trac-metadata/src/main/proto/trac/metadata/flow.proto
+++ b/trac-api/trac-metadata/src/main/proto/trac/metadata/flow.proto
@@ -53,8 +53,8 @@ message FlowSocket {
 
 message FlowEdge {
 
-  FlowSocket head = 1;
-  FlowSocket tail = 2;
+  FlowSocket from = 1;
+  FlowSocket to = 2;
 }
 
 

--- a/trac-libs/trac-lib-test/src/main/java/com/accenture/trac/test/meta/TestData.java
+++ b/trac-libs/trac-lib-test/src/main/java/com/accenture/trac/test/meta/TestData.java
@@ -299,11 +299,11 @@ public class TestData {
                 .putNodes("main_model", FlowNode.newBuilder().setNodeType(FlowNodeType.MODEL_NODE).build())
                 .putNodes("output_1", FlowNode.newBuilder().setNodeType(FlowNodeType.OUTPUT_NODE).build())
                 .addEdges(FlowEdge.newBuilder()
-                        .setTo(FlowSocket.newBuilder().setNode("main_model").setSocket("input_1"))
-                        .setFrom(FlowSocket.newBuilder().setNode("input_1")))
+                        .setTarget(FlowSocket.newBuilder().setNode("main_model").setSocket("input_1"))
+                        .setSource(FlowSocket.newBuilder().setNode("input_1")))
                 .addEdges(FlowEdge.newBuilder()
-                        .setTo(FlowSocket.newBuilder().setNode("output_1"))
-                        .setFrom(FlowSocket.newBuilder().setNode("main_model").setSocket("output_1"))))
+                        .setTarget(FlowSocket.newBuilder().setNode("output_1"))
+                        .setSource(FlowSocket.newBuilder().setNode("main_model").setSocket("output_1"))))
                 .build();
     }
 

--- a/trac-libs/trac-lib-test/src/main/java/com/accenture/trac/test/meta/TestData.java
+++ b/trac-libs/trac-lib-test/src/main/java/com/accenture/trac/test/meta/TestData.java
@@ -299,11 +299,11 @@ public class TestData {
                 .putNodes("main_model", FlowNode.newBuilder().setNodeType(FlowNodeType.MODEL_NODE).build())
                 .putNodes("output_1", FlowNode.newBuilder().setNodeType(FlowNodeType.OUTPUT_NODE).build())
                 .addEdges(FlowEdge.newBuilder()
-                        .setHead(FlowSocket.newBuilder().setNode("main_model").setSocket("input_1"))
-                        .setTail(FlowSocket.newBuilder().setNode("input_1")))
+                        .setTo(FlowSocket.newBuilder().setNode("main_model").setSocket("input_1"))
+                        .setFrom(FlowSocket.newBuilder().setNode("input_1")))
                 .addEdges(FlowEdge.newBuilder()
-                        .setHead(FlowSocket.newBuilder().setNode("output_1"))
-                        .setTail(FlowSocket.newBuilder().setNode("main_model").setSocket("output_1"))))
+                        .setTo(FlowSocket.newBuilder().setNode("output_1"))
+                        .setFrom(FlowSocket.newBuilder().setNode("main_model").setSocket("output_1"))))
                 .build();
     }
 

--- a/trac-services/trac-svc-meta/src/test/java/com/accenture/trac/svc/meta/api/MetadataWriteApiTest.java
+++ b/trac-services/trac-svc-meta/src/test/java/com/accenture/trac/svc/meta/api/MetadataWriteApiTest.java
@@ -60,13 +60,13 @@ abstract class MetadataWriteApiTest implements IDalTestable {
 
     // Include this test case as a unit test
     @ExtendWith(JdbcUnit.class)
-    static class Unit extends MetadataWriteApiTest {}
+    static class UnitTest extends MetadataWriteApiTest {}
 
     // Include this test case for integration against different database backends
     @org.junit.jupiter.api.Tag("integration")
     @org.junit.jupiter.api.Tag("int-metadb")
     @ExtendWith(JdbcIntegration.class)
-    static class Integration extends MetadataWriteApiTest {}
+    static class IntegrationTest extends MetadataWriteApiTest {}
 
     @Rule
     final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
@@ -229,8 +229,8 @@ abstract class MetadataWriteApiTest implements IDalTestable {
 
         var brokenEdges = validFlow.getFlow().toBuilder()
                 .addEdges(FlowEdge.newBuilder()
-                    .setHead(FlowSocket.newBuilder().setNode("another_absent_node").setSocket("missing_socket"))
-                    .setTail(FlowSocket.newBuilder().setNode("node_totally_not_present")))
+                    .setTo(FlowSocket.newBuilder().setNode("another_absent_node").setSocket("missing_socket"))
+                    .setFrom(FlowSocket.newBuilder().setNode("node_totally_not_present")))
                 .build();
 
         var invalidFlow = validFlow.toBuilder()

--- a/trac-services/trac-svc-meta/src/test/java/com/accenture/trac/svc/meta/api/MetadataWriteApiTest.java
+++ b/trac-services/trac-svc-meta/src/test/java/com/accenture/trac/svc/meta/api/MetadataWriteApiTest.java
@@ -229,8 +229,8 @@ abstract class MetadataWriteApiTest implements IDalTestable {
 
         var brokenEdges = validFlow.getFlow().toBuilder()
                 .addEdges(FlowEdge.newBuilder()
-                    .setTo(FlowSocket.newBuilder().setNode("another_absent_node").setSocket("missing_socket"))
-                    .setFrom(FlowSocket.newBuilder().setNode("node_totally_not_present")))
+                    .setTarget(FlowSocket.newBuilder().setNode("another_absent_node").setSocket("missing_socket"))
+                    .setSource(FlowSocket.newBuilder().setNode("node_totally_not_present")))
                 .build();
 
         var invalidFlow = validFlow.toBuilder()


### PR DESCRIPTION
Use "from" and "to" for flow edges
Instead of "head" and "tail", which are less obvious and could cause confusion